### PR TITLE
setColorScheme is depracated and replaced with setColorSchemeColors

### DIFF
--- a/templates/activities/SwipeRefreshLayout/root/src/app_package/SimpleActivity.java.ftl
+++ b/templates/activities/SwipeRefreshLayout/root/src/app_package/SimpleActivity.java.ftl
@@ -16,7 +16,7 @@ public class ${activityClass} extends ${(appCompat?has_content)?string('ActionBa
         super.onCreate(savedInstanceState);
         setContentView(R.layout.${layoutName});
 		mSwipeRefreshWidget = (SwipeRefreshLayout) findViewById(R.id.swipe_refresh_widget);
-        mSwipeRefreshWidget.setColorScheme(R.color.color1, R.color.color2, R.color.color3,
+        mSwipeRefreshWidget.setColorSchemeResources(R.color.color1, R.color.color2, R.color.color3,
                 R.color.color4);
         mSwipeRefreshWidget.setOnRefreshListener(this);
 		


### PR DESCRIPTION
[setColorScheme](https://developer.android.com/reference/android/support/v4/widget/SwipeRefreshLayout.html#setColorScheme%28int...%29) is deprecated and replaced by [setColorSchemeResources](https://developer.android.com/reference/android/support/v4/widget/SwipeRefreshLayout.html#setColorSchemeColors%28int...%29)
