### PR TITLE
ArrayAdapter + Activity Id Error

### DIFF
--- a/templates/custom/ArrayAdapterWithActivity/root/res/layout/activity_simple.xml.ftl
+++ b/templates/custom/ArrayAdapterWithActivity/root/res/layout/activity_simple.xml.ftl
@@ -6,12 +6,12 @@
     tools:context="${packageName}.${activityClass}">
 
     <ListView
-        android:id="@android:id/list"
+        android:id="@+id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
     <TextView
-        android:id="@android:id/empty"
+        android:id="@+id/empty"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center" />


### PR DESCRIPTION
Fixed Issue #7:
Since the Activity being generated doesn't extend ListActivity, we can't use the `@android:id/list` or `@android:id/empty` notations.
